### PR TITLE
Generates unique password per install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,7 @@ API_TOKEN  := $(shell yq .token ${HOME}/.replicated/config.yaml)
 SRC_DIR    := $(PROJECT_DIR)/src
 BUILD_DIR  := $(PROJECT_DIR)/build
 DEPLOY_DIR := $(PROJECT_DIR)/deploy
-
-FUNCTION_NAME := create-license
-LAMBDA_DIR    := $(SRC_DIR)/$(FUNCTION_NAME)
 TERRAFORM_DIR := $(DEPLOY_DIR)/terraform
-PACKAGE_NAME  := $(BUILD_DIR)/$(FUNCTION_NAME).zip
 
 TF_FLAGS := -var="build_directory=$(BUILD_DIR)" -var "aws_region=$(AWS_REGION)" -var "api_token=$(API_TOKEN)" -var "owner=${USER}"
 
@@ -22,14 +18,17 @@ all: deploy
 
 # prepare the build directory
 prepare: 
-	@mkdir -p $(BUILD_DIR)/$(FUNCTION_NAME)
-	@cp -r $(LAMBDA_DIR)/* $(BUILD_DIR)/$(FUNCTION_NAME)
+	@mkdir -p $(BUILD_DIR)
+	@cp -r $(SRC_DIR)/* ${BUILD_DIR}
  
 # Package Lambda function
 package: prepare
-	cd $(BUILD_DIR)/$(FUNCTION_NAME) && \
+	cd $(BUILD_DIR)/create-license && \
 		pip install -r requirements.txt -t . --upgrade && \
-		zip -r $(PACKAGE_NAME) . 
+		zip -r ${BUILD_DIR}/create-license.zip . 
+	cd $(BUILD_DIR)/generate-password && \
+		pip install -r requirements.txt -t . --upgrade && \
+		zip -r ${BUILD_DIR}/generate-password.zip . 
 
 # Deploy with Terraform
 plan: package

--- a/deploy/terraform/generate-password.tf
+++ b/deploy/terraform/generate-password.tf
@@ -1,0 +1,70 @@
+resource "aws_lambda_function" "generate_password" {
+  function_name = "generate-${var.application}-password"
+  architectures = ["arm64"]
+
+  handler       = "main.handler"  # Assuming your Python file is named lambda_function.py
+  role          = aws_iam_role.password_lambda_exec_role.arn
+  runtime       = "python3.11"
+
+  filename         = "${var.build_directory}/generate-password.zip"
+  source_code_hash = filebase64sha256("${var.build_directory}/generate-password.zip")
+}
+
+resource "aws_iam_policy" "generate_password_secrets_manager" {
+  name   = "generate-${var.application}-password-secrets-manager"
+  policy = data.aws_iam_policy_document.generate_password_secrets_manager.json
+}
+
+data "aws_iam_policy_document" "generate_password_secrets_manager" {
+  statement {
+    actions = [
+      "secretsmanager:CreateSecret"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:DeleteSecret"
+    ]
+    resources = [
+      "arn:aws:secretsmanager:*:*:secret:*-admin-console-*"
+    ]
+  }
+}
+
+data "aws_iam_policy" "password_lambda_exec_policy" {
+  name = "AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "generate_password_secrets_manager" {
+  role       = aws_iam_role.password_lambda_exec_role.id
+  policy_arn = aws_iam_policy.generate_password_secrets_manager.arn
+}
+
+resource "aws_iam_role_policy_attachment" "password_lambda_exec_policy" {
+  role       = aws_iam_role.password_lambda_exec_role.id
+  policy_arn = data.aws_iam_policy.password_lambda_exec_policy.arn
+}
+
+resource "aws_iam_role" "password_lambda_exec_role" {
+  name = "${var.application}-password-lambda-exec"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        },
+      },
+    ],
+  })
+}
+

--- a/deploy/terraform/output.tf
+++ b/deploy/terraform/output.tf
@@ -1,3 +1,7 @@
 output "template_url" {
   value = "https://${aws_s3_bucket.template_bucket.bucket}.s3.${var.aws_region}.amazonaws.com/${aws_s3_object.cloudformation_template.key}"
 }
+
+output "stack_role_arn" {
+  value = aws_iam_role.stack_role.arn
+}

--- a/deploy/terraform/templates/slackernews_cloudformation.tftpl
+++ b/deploy/terraform/templates/slackernews_cloudformation.tftpl
@@ -43,12 +43,18 @@ Resources:
   CreateLicense:
     Type: Custom::LambdaTrigger
     Properties:
-      ServiceToken: ${lambda_function_arn}
+      ServiceToken: ${license_function_arn}
       Name: !Sub '$${AWS::AccountId}-$${AWS::Region}-$${AWS::StackId}' 
       Email: !Ref Email
       AppId: ${app_id}
       Channel: !If [ IsBeta, Beta, Stable ]
       Type: !FindInMap [ LicenseType, !Ref SubscriptionType, Type ]
+
+  GeneratePassword:
+    Type: Custom::LambdaTrigger
+    Properties:
+      ServiceToken: ${password_function_arn}
+      SecretName: !Sub '$${AWS::StackName}-admin-console' 
 
   InitialNode:
     Type: AWS::EC2::Instance
@@ -65,6 +71,7 @@ Resources:
             - InstallerUri: !GetAtt CreateLicense.InstallerUri
               DownloadToken: !GetAtt CreateLicense.DownloadToken
               PublicKey: !Ref PublicKey
+              AdminConsolePassword: !GetAtt GeneratePassword.Password
 
   EmbeddedClusterSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -102,6 +109,6 @@ Outputs:
   ConsoleUri:
     Description: URI to access the admin console of the new cluster
     Value: !Sub http://$${InitialNode.PublicIp}:30000
-  ConsolePassword:
-    Description: Password to log into the admin console
-    Value: ${admin_console_password}
+  PasswordSecret:
+    Description: Secrets manager secret containing the initial Admin Console password
+    Value: !GetAtt GeneratePassword.SecretArn

--- a/deploy/terraform/templates/user-data.tftpl
+++ b/deploy/terraform/templates/user-data.tftpl
@@ -80,4 +80,4 @@ runcmd:
 - |
   # use the KOTS CLI to reset the admin console password`
   export PATH=$${!PATH}:/var/lib/embedded-cluster/bin
-  echo ${admin_console_password} | kubectl kots reset-password --kubeconfig /var/lib/k0s/pki/admin.conf --namespace kotsadm
+  echo "$${AdminConsolePassword}" | kubectl kots reset-password --kubeconfig /var/lib/k0s/pki/admin.conf --namespace kotsadm

--- a/src/create-license/customer.py
+++ b/src/create-license/customer.py
@@ -15,7 +15,7 @@ class Customer:
 
   @classmethod
   def create(cls,api_token, name, email, app_id, expires_at, license_type, channel):
-    logger.debug("creating new customer instance for {name}".format(name=name))
+    logger.debug(f'creating new customer instance for {name}')
     instance = cls(api_token)
     instance.id = None
     instance.api_token = api_token
@@ -36,7 +36,7 @@ class Customer:
     instance.isIdentityServiceSupported = False
     instance.isSnapshotSupported = False
 
-    logger.debug("saving new customer instance for {name}".format(name=name))
+    logger.debug(f'saving new customer instance for {name}')
     instance.save()
     return instance
 

--- a/src/generate-password/main.py
+++ b/src/generate-password/main.py
@@ -1,0 +1,34 @@
+from crhelper import CfnResource
+import logging
+
+from password import Password
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
+helper = CfnResource(
+    json_logging=False,
+    log_level='DEBUG',
+    boto_level='CRITICAL'
+)
+
+def handler(event, context):
+    helper(event, context)
+
+@helper.create
+def create(event, context):
+    logger.info("generating admin console password")
+    secret_name = event.get('ResourceProperties').get("SecretName")
+    logger.info(f'creating secret {secret_name}')
+    password = Password(name=secret_name)
+    helper.Data.update({'SecretArn': password.arn})
+    helper.Data.update({'Password': password.value})
+    return password.arn
+
+@helper.delete
+def delete(event, context):
+    passwordArn = event['PhysicalResourceId']
+    logger.info(f'deleting password: {passwordArn}')
+    password = Password(arn=passwordArn)
+    password.delete()
+

--- a/src/generate-password/password.py
+++ b/src/generate-password/password.py
@@ -1,0 +1,49 @@
+import logging
+
+import boto3
+secrets_manager = boto3.client('secretsmanager')
+
+import petname
+import base64
+import uuid
+import bcrypt
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
+class Password:
+
+  def __init__(self, name=None, arn=None):
+    if arn is not None:
+      self.arn = arn
+      self.__load(arn)
+    else: 
+      self.name = name
+      self.__generate_password()
+      self.arn = None
+      logger.debug(f'created password {name}, now saving it')
+      self.save()
+
+  def __generate_password(self):
+    base   = petname.Generate(3, "-", 10)
+    random = uuid.uuid4().hex[0:6]
+
+    self.value = base + "-" + random
+
+  def __load(self,secret_arn):
+    logger.debug(f'loading password {secret_arn}')
+    response = secrets_manager.get_secret_value(SecretId=secret_arn)
+    self.name = response['Name']
+    self.value = response['SecretString']
+
+  def save(self):
+    logger.debug('saving password {name}'.format(name=self.name))
+    if self.arn is None:
+      response = secrets_manager.create_secret( Name=self.name, SecretString=self.value )
+      self.arn = response['ARN']
+    else:
+      response = secrets_manager.update_secret( SecretId=self.arn, SecretString=self.value )
+
+  def delete(self):
+    logger.debug('deleteing password {name} ({arn})'.format(name=self.name, arn=self.arn))
+    secrets_manager.delete_secret( SecretId=self.arn )

--- a/src/generate-password/requirements.txt
+++ b/src/generate-password/requirements.txt
@@ -1,0 +1,2 @@
+crhelper
+petname


### PR DESCRIPTION
TL;DR
-----

Moves admin console password generate from Terraform to
CloudFormation

Details
-------

Addresses the limitation of all instance having the same default
password for the Admin Console. It was limited before because the
Terraform templates generated the password and the user-data set
the value. Now the password is treated as a custom resource in
CloudFormation.

The CloudFormation custom resource uses the Python petname
library to generate the password, then saves it to AWS Secrets
Manager. This also means the password is not explicitly written
out as a stack output.

Once the isntance is running, the user can get the Admin Console
password from Secrets Manager and use it at the URL for the
console that is part of the stack outputs.