### PR TITLE
Waits for Admin Console before stack is ready

### DIFF
--- a/deploy/terraform/templates/slackernews_cloudformation.tftpl
+++ b/deploy/terraform/templates/slackernews_cloudformation.tftpl
@@ -169,6 +169,9 @@ Resources:
 
   InitialNode:
     Type: AWS::EC2::Instance
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: 'PT15M'
     Properties:
       ImageId: !FindInMap [ Ami, !Ref AWS::Region, AmiId ]
       InstanceType: !Ref InstanceType   
@@ -189,6 +192,9 @@ Resources:
               DownloadToken: !GetAtt CreateLicense.DownloadToken
               PublicKey: !Ref PublicKey
               AdminConsolePassword: !GetAtt GeneratePassword.Password
+              StackName: !Ref AWS::StackName 
+              ResourceName: InitialNode 
+              Region: !Ref AWS::Region
 
   EmbeddedClusterSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'

--- a/deploy/terraform/templates/user-data.tftpl
+++ b/deploy/terraform/templates/user-data.tftpl
@@ -17,6 +17,7 @@ packages:
 - ca-certificates
 - curl
 - jq
+- python3-pip
 
 # Update apt database and upgrade packages on first boot
 package_update: true
@@ -81,3 +82,12 @@ runcmd:
   # use the KOTS CLI to reset the admin console password`
   export PATH=$${!PATH}:/var/lib/embedded-cluster/bin
   echo "$${AdminConsolePassword}" | kubectl kots reset-password --kubeconfig /var/lib/k0s/pki/admin.conf --namespace kotsadm
+
+- |
+  # install cloud formation bootstrap scripts and signal completion
+  curl https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz -o /tmp/aws-cfn-bootstrap-latest.tar.gz \
+    && pip3 install /tmp/aws-cfn-bootstrap-latest.tar.gz \
+    && rm /tmp/aws-cfn-bootstrap-latest.tar.gz
+  /usr/local/bin/cfn-signal --success true --stack $${StackName} --resource $${ResourceName} --region $${Region}
+
+  


### PR DESCRIPTION
TL;DR
-----

Updates user data to signal CloudFormation when Admin Console
is ready

Details
-------

Resolves the remaining limitation of the CloudFormation install
where cluster readiness was unclear. This change makes use of the
EC2 creation policy in CloudFormation to wait on a signal from
the instance. That signal comes from the instance user data and
is sent after the cluster install completes (so Admin Console is
ready) and the password is changed (so the generated password is
the right one.