### PR TITLE
Provides a VPC for the cluster

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -43,7 +43,32 @@ data "aws_iam_policy_document" "stack_policy" {
                   "ec2:DeleteSecurityGroup",
                   "ec2:AuthorizeSecurityGroupIngress",
                   "ec2:RevokeSecurityGroupIngress",
-                  "ec2:DescribeSecurityGroups" 
+                  "ec2:DescribeSecurityGroups",
+                  "ec2:CreateVpc",
+                  "ec2:DeleteVpc",
+                  "ec2:ModifyVpcAttribute",
+                  "ec2:DescribeVpcs",
+                  "ec2:CreateSubnet",
+                  "ec2:DeleteSubnet",
+                  "ec2:ModifySubnetAttribute",
+                  "ec2:DescribeSubnets",
+                  "ec2:CreateInternetGateway",
+                  "ec2:DeleteInternetGateway",
+                  "ec2:AttachInternetGateway",
+                  "ec2:DetachInternetGateway",
+                  "ec2:DescribeInternetGateways",
+                  "ec2:CreateRoute",
+                  "ec2:CreateRouteTable",
+                  "ec2:DeleteRoute",
+                  "ec2:DeleteRouteTable",
+                  "ec2:AssociateRouteTable",
+                  "ec2:DisassociateRouteTable",
+                  "ec2:DescribeRouteTables",
+                  "ec2:CreateSecurityGroup",
+                  "ec2:DeleteSecurityGroup",
+                  "ec2:AuthorizeSecurityGroupIngress",
+                  "ec2:RevokeSecurityGroupIngress",
+                  "ec2:DescribeSecurityGroups"
                 ]
     resources = [ "*" ]
   }

--- a/deploy/terraform/templates/slackernews_cloudformation.tftpl
+++ b/deploy/terraform/templates/slackernews_cloudformation.tftpl
@@ -175,8 +175,11 @@ Resources:
     Properties:
       ImageId: !FindInMap [ Ami, !Ref AWS::Region, AmiId ]
       InstanceType: !Ref InstanceType   
-      SecurityGroups:
-        - !Ref EmbeddedClusterSecurityGroup
+      SubnetId: !Ref ClusterSubnet
+      SecurityGroupIds:
+        - Fn::GetAtt:
+          - ClusterSecurityGroup
+          - GroupId
       BlockDeviceMappings:
         - DeviceName: "/dev/sda1" 
           Ebs:
@@ -196,10 +199,53 @@ Resources:
               ResourceName: InitialNode 
               Region: !Ref AWS::Region
 
-  EmbeddedClusterSecurityGroup:
+  ClusterVPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.20.0.0/16
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+
+  ClusterSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref ClusterVPC
+      CidrBlock: 10.20.1.0/24
+      MapPublicIpOnLaunch: true
+
+  ClusterInternetGateway:
+    Type: AWS::EC2::InternetGateway
+
+  AttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref ClusterVPC
+      InternetGatewayId: !Ref ClusterInternetGateway
+
+  ClusterRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref ClusterVPC
+
+  ClusterRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref ClusterRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref ClusterInternetGateway
+
+  ClusterSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref ClusterSubnet
+      RouteTableId: !Ref ClusterRouteTable
+
+  ClusterSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
       GroupDescription: Enable access via SSH and the Admin Console
+      VpcId: !Ref ClusterVPC
       SecurityGroupIngress:
         # SSH
         - IpProtocol: tcp


### PR DESCRIPTION
TL;DR
-----

Places cluster in a new VPC instead of using the default

Details
-------

Creates a VPC for the cluster. Amazon reommends/requires not
installing into the default VPC, and that's what I was doing
first. This may not last, I may decided in a feature version
to prompt for a VPC to install into.